### PR TITLE
Minor cleanup + replace optparse with argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,39 @@ Imagine you have a hundred or a thousand artists or researchers all busily colla
 
 ## Usage
 ```
-Usage: capacity_by_user.py [options] path
+usage: capacity_by_user.py [-h] [-U USER] [-P PASSWORD] [-C CLUSTER] [-p PORT]
+                           [-s SAMPLES] [-c CONCURRENCY] [-m MIN_SAMPLES]
+                           [-x MAX_LEAVES] [-D DOLLARS_PER_TERABYTE] [-i] [-A]
+                           path
 
-Options:
+positional arguments:
+  path                  Filesystem path to sample
+
+optional arguments:
   -h, --help            show this help message and exit
-  -U USER, --user=USER  The user to connect as
-  -P PASSWORD, --password=PASSWORD
-                        The password to connect with
-  -C CLUSTER, --cluster=CLUSTER
-                        The cluster to connect to
-  -p PORT, --port=PORT  The port to connect to
-  -s SAMPLES, --samples=SAMPLES
-                        The number of samples to take
-  -c CONCURRENCY, --concurrency=CONCURRENCY
-                        The number of threads to query with
-  -m MIN_SAMPLES, --min-samples=MIN_SAMPLES
+  -U USER, --user USER  The user to connect as (default: admin)
+  -P PASSWORD, --password PASSWORD
+                        The password to connect with (default: admin)
+  -C CLUSTER, --cluster CLUSTER
+                        The hostname of the cluster to connect to (default:
+                        qumulo)
+  -p PORT, --port PORT  The port to connect to (default: 8000)
+  -s SAMPLES, --samples SAMPLES
+                        The number of samples to take (default: 2000)
+  -c CONCURRENCY, --concurrency CONCURRENCY
+                        The number of threads to query with (default: 10)
+  -m MIN_SAMPLES, --min-samples MIN_SAMPLES
                         The minimum number of samples to show at a leaf in
-                        output
-  -x MAX_LEAVES, --max-leaves=MAX_LEAVES
+                        output (default: 5)
+  -x MAX_LEAVES, --max-leaves MAX_LEAVES
                         The maximum number of leaves to show per user
-  -D DOLLARS_PER_TERABYTE, --dollars-per-terabyte=DOLLARS_PER_TERABYTE
+                        (default: 30)
+  -D DOLLARS_PER_TERABYTE, --dollars-per-terabyte DOLLARS_PER_TERABYTE
                         Show capacity in dollars. Set conversion factor in
                         $/TB/month
+  -i, --confidence-interval
+                        Show 95% confidence intervals
+  -A, --allow-self-signed-server
+                        Silently connect to self-signed servers
 ```
 

--- a/capacity_by_user.py
+++ b/capacity_by_user.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from qumulo.rest_client import RestClient
 import os
 import pwd

--- a/capacity_by_user.py
+++ b/capacity_by_user.py
@@ -3,6 +3,7 @@
 from qumulo.rest_client import RestClient
 import os
 import pwd
+import sys
 import ssl
 import heapq
 from optparse import OptionParser
@@ -281,5 +282,9 @@ def process_command_line():
 
     return opts, args
 
-(opts, args) = process_command_line()
-do_it(opts, args)
+def main(_):
+    (opts, args) = process_command_line()
+    do_it(opts, args)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/capacity_by_user.py
+++ b/capacity_by_user.py
@@ -142,7 +142,7 @@ def get_owner_vec(pool, credentials, samples, args):
     owner_id_sublists = pool.map(get_file_attrs, sublists)
     return sum(owner_id_sublists, [])
 
-def do_it(args):
+def main(args):
     credentials = {"user" : args.user,
                    "password" : args.password,
                    "cluster" : args.cluster}
@@ -217,7 +217,7 @@ def do_it(args):
 
         print tree.__str__("    ", lambda x: format_capacity(x))
 
-def process_command_line():
+def process_command_line(args):
     parser = ArgumentParser()
     parser.add_argument("-U", "--user", default="admin",
             help="The user to connect as (default: %(default)s)")
@@ -257,11 +257,7 @@ def process_command_line():
 
     parser.add_argument("path", help="Filesystem path to sample")
 
-    return parser.parse_args()
-
-def main(_):
-    args = process_command_line()
-    do_it(args)
+    return parser.parse_args(args)
 
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    main(process_command_line(sys.argv[1:]))


### PR DESCRIPTION
Just some minor cleanup to switch from the deprecated `optparse` module to the more modern `argparse` module.